### PR TITLE
Fix name updates don't reflect immediately on the frontend

### DIFF
--- a/exercises/frontend/src/app/page.tsx
+++ b/exercises/frontend/src/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL;
 
-export const Home = () => {
+const Home = () => {
   const [fetchedFirstName, setFetchedFirstName] = useState<string | null>(null);
   const [fetchedLastName, setFetchedLastName] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -72,12 +72,10 @@ const NameEditor = (props: {
   } = props;
   const [firstName, setFirstName] = useState<string>(fetchedFirstName || "");
   const [lastName, setLastName] = useState<string>(fetchedLastName || "");
-  const [fullName, setFullName] = useState<string | null>(null);
 
-  useEffect(() => {
-    setFullName(`${firstName} ${lastName}`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const trimmedFullName = `${firstName} ${lastName}`.trim();
+  // Just show the greeting if fullName is not empty
+  const shouldShowGreeting = trimmedFullName.length > 0;
 
   return (
     <div>
@@ -99,7 +97,7 @@ const NameEditor = (props: {
         <button onClick={() => onSaveNames(firstName, lastName)}>Save</button>
       </div>
       <div>
-        {fullName && (<p>Hello, {fullName}!</p>)}
+        {shouldShowGreeting && (<p>Hello, {trimmedFullName}!</p>)}
       </div>
     </div>
   );


### PR DESCRIPTION
# Overview
## **Issue:**
- Name updates don't reflect immediately on the frontend

## **Fix:**
**- Fix and root cause of `Name updates don't reflect immediately on the frontend`:**
  + **Root cause:** The previous useEffect was missing dependencies, causing delayed updates to fullName. Since the effect was only running on the initial render, subsequent changes to firstName and lastName were not reflected immediately.
  + **Fix:** By removing useEffect and useState for fullName, and calculating fullName directly in the render logic, updates to firstName and lastName now reflect immediately on the UI. This works because firstName and lastName are still managed as useState, which ensures reactivity.

**- Additional fixes:**
- Removed the unnecessary export for Home as we already export default Home at the end of the file.
- Fixed greeting rendering logic: ensured it doesn't render when fullName is just an empty string or space (" ").

# Reproduce the issue:

https://github.com/user-attachments/assets/64f2c74c-5823-49cc-bf38-9db4e33624fc



# Testing video

https://github.com/user-attachments/assets/ec01d3c0-5fc5-4c8e-a786-351a85305fca

